### PR TITLE
Fix typos in currying excercise, clarify long-delay-invocation behavior

### DIFF
--- a/exercises/curry_function/problem.md
+++ b/exercises/curry_function/problem.md
@@ -28,7 +28,7 @@ follows:
 var curriedAbc = curryFunc(abc);
 curriedAbc(a)(b)(c); // Now we can call original function like this...
 curriedAbc(a,b)(c); //or this
-curriedAbc(a)b,c); //or this
+curriedAbc(a)(b,c); //or this
 curriedAbc(a,b,c); //or this
 ```
 

--- a/exercises/curry_function/problem.md
+++ b/exercises/curry_function/problem.md
@@ -26,10 +26,10 @@ follows:
 
 ```js
 var curriedAbc = curryFunc(abc);
-currienAbc(a)(b)(c); // Now we can call original function like this...
-currienAbc(a,b)(c); //or this
-currienAbc(a)b,c); //or this
-currienAbc(a,b,c); //or this
+curriedAbc(a)(b)(c); // Now we can call original function like this...
+curriedAbc(a,b)(c); //or this
+curriedAbc(a)b,c); //or this
+curriedAbc(a,b,c); //or this
 ```
 
 ----------------------------------------------------------------------

--- a/exercises/long_delay_invocation/problem.md
+++ b/exercises/long_delay_invocation/problem.md
@@ -6,7 +6,7 @@ simple it is? Let's make it a little more complex. Are you ready?
 ## Task
 
 Write a function that takes one argument for each invocation. Each time it is
-called, it should add its argument to a running total. If it is called with no
+called, it should add its argument to a running total and return itself. If it is called with no
 arguments, it should return the sum of all the arguments passed.
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
This PR does two things:
- fix minor typos in the last excercise
- clarify the fact that the `long-delay-invocation` excercise expects the function to return itself in case a value is passed (I tripped over that)
