### PR TITLE
Fix error messages for callAndApply exercise

### DIFF
--- a/exercises/call_and_apply/exercise.js
+++ b/exercises/call_and_apply/exercise.js
@@ -30,8 +30,9 @@ exercise.addProcessor(function (mode, callback) {
     var personForSolutionCall = {name: "Brij", age: 28, tShirtSize: 'L'};
     var personForSubmissionCall = {name: "Brij", age: 28, tShirtSize: 'L'};
     
-    var callerSolutionResult = this.solutionModule.caller(personForSolutionCall, update, 'Kishor', 29, 'XL');
-    var callerSubmissionResult = this.submissionModule.caller(personForSubmissionCall, update, 'Kishor', 29, 'XL');
+    // invoke `update` and mutate the test subjects
+    this.solutionModule.caller(personForSolutionCall, update, 'Kishor', 29, 'XL');
+    this.submissionModule.caller(personForSubmissionCall, update, 'Kishor', 29, 'XL');
 
     if (personForSubmissionCall.name !== personForSolutionCall.name || personForSubmissionCall.age !== personForSolutionCall.age || personForSubmissionCall.tShirtSize !== personForSolutionCall.tShirtSize) {
         exercise.emit('fail', 'Call method result in error. \nExpected result: ' + showObjectInLog(personForSolutionCall) + ' \nActual result: '+ showObjectInLog(personForSubmissionCall));
@@ -41,8 +42,10 @@ exercise.addProcessor(function (mode, callback) {
     var personForSolutionApply = {name: "Kishor", age: 24, tShirtSize: 'S'};
     var personForSubmissionApply = {name: "Kishor", age: 24, tShirtSize: 'S'};
     
-    var applierSolutionResult = this.solutionModule.applier(personForSolutionApply, update, ['Brij', 26, 'M']);
-    var applierSubmissionResult = this.submissionModule.applier(personForSubmissionApply, update, ['Brij', 26, 'M']);
+    // invoke `update` and mutate the test subjects
+    this.solutionModule.applier(personForSolutionApply, update, ['Brij', 26, 'M']);
+    this.submissionModule.applier(personForSubmissionApply, update, ['Brij', 26, 'M']);
+
     if (personForSubmissionApply.name !== personForSolutionApply.name || personForSubmissionApply.age !== personForSolutionApply.age || personForSubmissionApply.tShirtSize !== personForSolutionApply.tShirtSize) {
         exercise.emit('fail', 'Apply method result in error. \nExpected result: ' + showObjectInLog(personForSolutionApply) + ' \nActual result: '+ showObjectInLog(personForSubmissionApply));
         pass = false;

--- a/exercises/call_and_apply/exercise.js
+++ b/exercises/call_and_apply/exercise.js
@@ -4,6 +4,7 @@ var exercise      = require('workshopper-exercise')()
   , comparestdout = require('workshopper-exercise/comparestdout')
   , path          = require('path')
   , fs = require('fs')
+  , util = require('util')
 
 
 // checks that the submission file actually exists
@@ -25,6 +26,7 @@ exercise.addProcessor(function (mode, callback) {
         this.age = age;
         this.tShirtSize = tShirtSize;
     };
+
     var personForSolutionCall = {name: "Brij", age: 28, tShirtSize: 'L'};
     var personForSubmissionCall = {name: "Brij", age: 28, tShirtSize: 'L'};
     
@@ -32,7 +34,7 @@ exercise.addProcessor(function (mode, callback) {
     var callerSubmissionResult = this.submissionModule.caller(personForSubmissionCall, update, 'Kishor', 29, 'XL');
 
     if (personForSubmissionCall.name !== personForSolutionCall.name || personForSubmissionCall.age !== personForSolutionCall.age || personForSubmissionCall.tShirtSize !== personForSolutionCall.tShirtSize) {
-        exercise.emit('fail', 'Call method result in error. \nExpected result: ' + personForSolutionCall + ' \nActual result: '+ personForSubmissionCall);
+        exercise.emit('fail', 'Call method result in error. \nExpected result: ' + showObjectInLog(personForSolutionCall) + ' \nActual result: '+ showObjectInLog(personForSubmissionCall));
         pass = false;
     }
 
@@ -42,7 +44,7 @@ exercise.addProcessor(function (mode, callback) {
     var applierSolutionResult = this.solutionModule.applier(personForSolutionApply, update, ['Brij', 26, 'M']);
     var applierSubmissionResult = this.submissionModule.applier(personForSubmissionApply, update, ['Brij', 26, 'M']);
     if (personForSubmissionApply.name !== personForSolutionApply.name || personForSubmissionApply.age !== personForSolutionApply.age || personForSubmissionApply.tShirtSize !== personForSolutionApply.tShirtSize) {
-        exercise.emit('fail', 'Apply method result in error. \nExpected result: ' + applierSolutionResult + ' \nActual result: '+ applierSubmissionResult);
+        exercise.emit('fail', 'Apply method result in error. \nExpected result: ' + showObjectInLog(personForSolutionApply) + ' \nActual result: '+ showObjectInLog(personForSubmissionApply));
         pass = false;
     }
     process.nextTick(function () {
@@ -71,6 +73,12 @@ exercise.getSolutionFiles = function (callback) {
 
 function getSolutionPath() {
     return path.join(exercise.dir, './solution/');
+}
+
+// Print out an object's key value pairs when that object is used in `console.log`.
+// Normally, would output: `[object Object]`.
+function showObjectInLog(obj) {
+    return util.inspect(obj);
 }
 
 module.exports = exercise

--- a/exercises/call_and_apply/solution/solution.js
+++ b/exercises/call_and_apply/solution/solution.js
@@ -3,7 +3,7 @@ var callAndApply = {
     method.call(object, nameArg, ageArg, tShirtSizeArg)
   },
   applier: function (object, method, argumentsArr) {
-    return method.apply(object, argumentsArr);
+    method.apply(object, argumentsArr);
   }
 };
 module.exports = callAndApply;


### PR DESCRIPTION
For the exercise, `callAndApply`, the error message currently is:

``` sh
✗ Call method result in error. 
Expected result: [object Object] 
Actual result: [object Object]
```

With these changes it would be:

``` sh
✗ Call method result in error. 
Expected result: { name: 'Kishor', age: 29, tShirtSize: 'XL' } 
Actual result: { name: 'Brij', age: 28, tShirtSize: 'L' }
```

Also, made a slight change by removing some unused variables. The test just mutates the objects, in-place and a return statement is not necessary.
